### PR TITLE
Changes to pass all posix PJD tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,10 +118,12 @@ where `<mode>` is one of `posix`, `sync` or `strict`.  Example: `make -C tests p
 
 Tip: Redirect stderr for less verbose output: e.g `make test 2>/dev/null`
 
-## Notes
+## Implementation Notes
 1. Only regular files, block special files and directories (only for consistency guarantees) are handled by SplitFS, the other file types are delegated to POSIX.  
 2. Only files in the persistent memory mount are handled by SplitFS, rest are delegated to POSIX.  
 Currently this is only done by examination of absolute paths specified, we aim to have this check for relative paths too, soon.
+3. Currently, the persistent memory mount is assumed to be at `/mnt/pmem_emul/`.  
+We aim to have this controlled via a runtime environment variable soon.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -118,6 +118,11 @@ where `<mode>` is one of `posix`, `sync` or `strict`.  Example: `make -C tests p
 
 Tip: Redirect stderr for less verbose output: e.g `make test 2>/dev/null`
 
+## Notes
+1. Only regular files, block special files and directories (only for consistency guarantees) are handled by SplitFS, the other file types are delegated to POSIX.  
+2. Only files in the persistent memory mount are handled by SplitFS, rest are delegated to POSIX.  
+Currently this is only done by examination of absolute paths specified, we aim to have this check for relative paths too, soon.
+
 ## License
 
 Copyright for SplitFS is held by the University of Texas at Austin. Please contact us if you would like to obtain a license to use SplitFS in your commercial product.

--- a/README.md
+++ b/README.md
@@ -101,14 +101,7 @@ SplitFS is under active development.
 2. The current implementation of SplitFS works correctly for the following applictions: `LevelDB running YCSB, SQLite running TPCC, tar, git, rsync`. This limitation is purely due to the state of the implementation, and we aim to increase the coverage of applications by supporting more system calls in the future.
 
 ## Testing
-[PJD POSIX Test Suite](https://www.tuxera.com/community/posix-test-suite/) that tests primarily the metadata operations was run on SplitFS and yielded the following result.  
-Tests Passed: 1944 out of a total of 1957.  
-Tests that failed include: 
-1. Tests on `link` (tests 56-58, 63-65 in links/00.t)
-2. Tests on `rename` (tests 49, 53, 57, 61 in rename/00.t)
-3. Tests on `unlink` (tests 17, 22, 53 in in unlink/00.t)  
-
-We aim to to improve this to a 100% pass rate soon.
+[PJD POSIX Test Suite](https://www.tuxera.com/community/posix-test-suite/) that tests primarily the metadata operations was run on SplitFS successfully.  
 
 **Running the Test Suite**  
 Before running the tests, make sure you have [set-up ext4-DAX](#set-up-ext4-DAX)  

--- a/splitfs/fileops_hub.c
+++ b/splitfs/fileops_hub.c
@@ -639,7 +639,6 @@ RETT_OPEN _hub_OPEN(INTF_OPEN)
 
 #endif
 
-#if WORKLOAD_TAR | WORKLOAD_GIT | WORKLOAD_RSYNC
 
 	if(path[0] == '/' && path[1] == 'v' && path[2] == 'a' && path[3] == 'r') {
 		op_to_use = _hub_fileops;
@@ -692,7 +691,6 @@ RETT_OPEN _hub_OPEN(INTF_OPEN)
 		
 	}
 	
-#endif // WORKLOAD_TAR
 	
 	// op_to_use = _hub_managed_fileops;	
 	assert(op_to_use != NULL);

--- a/splitfs/fileops_hub.c
+++ b/splitfs/fileops_hub.c
@@ -639,11 +639,21 @@ RETT_OPEN _hub_OPEN(INTF_OPEN)
 
 #endif
 
+		/* In case of absoulate path specified, check if it belongs to the persistent memory 
+	 	* mount and only then use SplitFS, else redirect to POSIX
+		*/
+	if(path[0] == '/') {
+		int len = strlen(NVMM_PATH);
+		char dest[len + 1];
+		dest[len] = '\0';
+		strncpy(dest, path, len);
 
-	if(path[0] == '/' && path[1] == 'v' && path[2] == 'a' && path[3] == 'r') {
-		op_to_use = _hub_fileops;
-		goto opening;
+		if(strcmp(dest, NVMM_PATH) != 0) {
+			op_to_use = _hub_fileops;
+			goto opening;
+		}
 	}
+
 
 	/*
         if (!strcmp(path, "/dev/shm/exec-ledger") || !strcmp(path, "/dev/shm/exec-hub")) {


### PR DESCRIPTION
1. Test suite uses /dev/urandom to generate random names for the files that it creates.
2. When used with SplitFS, /dev/urandom (handled by SplitFS) always returns 0 causing the same random number to be generated for all files. This affects the tests that do comparison between two different files --- they end up being compared with themselves due to same name generated.

Delegate the non-regular file operations to posix - this was already done but only for tar workloads.
This change does the same for all workloads.