### PR TITLE
Multithread filebench fix

### DIFF
--- a/splitfs/fileops_nvp.c
+++ b/splitfs/fileops_nvp.c
@@ -3524,7 +3524,7 @@ RETT_PWRITE write_to_file_mmap(int file,
 	if (temp_fd < 0)
 		assert(0);
 
-	writeable = _nvp_fileops->READ(fd, (void *)mmap_addr, extent_length) == extent_length;
+	writeable = _nvp_fileops->READ(fd, (void *)mmap_addr, 1) == 1;
 
 	if (writeable) {
 		if(MEMCPY_NON_TEMPORAL((char *)mmap_addr, buf, extent_length) == NULL) {

--- a/splitfs/fileops_nvp.c
+++ b/splitfs/fileops_nvp.c
@@ -3536,8 +3536,8 @@ RETT_PWRITE write_to_file_mmap(int file,
 		assert(0);
 	}
 
-	close(temp_fd);
-	
+	_nvp_fileops->CLOSE(temp_fd);
+
 	//_mm_sfence();
 	//num_mfence++;
 	num_write_nontemporal++;

--- a/splitfs/fileops_nvp.c
+++ b/splitfs/fileops_nvp.c
@@ -764,8 +764,11 @@ static inline size_t dynamic_remap(int file_fd, struct NVNode *node, int close)
 		app_start_off = node->dr_info.dr_offset_start +
 			file_start_off - node->true_length;
 	       		
-		if (node->dr_info.dr_offset_start > node->dr_info.dr_offset_end)
+		if (node->dr_info.dr_offset_start > node->dr_info.dr_offset_end) {
+			MSG("%s: node->dr_info.dr_offset_start = %lu, node->dr_info.dr_offset_end = %lu\n",
+			    __func__, node->dr_info.dr_offset_start, node->dr_info.dr_offset_end);
 			assert(0);
+		}
 		if (app_start_off > node->dr_info.dr_offset_end)
 			assert(0);
 		if ((app_start_off % MMAP_PAGE_SIZE) != (file_start_off % MMAP_PAGE_SIZE))

--- a/splitfs/fileops_nvp.c
+++ b/splitfs/fileops_nvp.c
@@ -3513,14 +3513,11 @@ RETT_PWRITE write_to_file_mmap(int file,
 #if NON_TEMPORAL_WRITES
 
 	DEBUG_FILE("%s: memcpy args: buf = %p, mmap_addr = %p, length = %lu. File off = %lld. Inode = %lu\n", __func__, buf, (void *) mmap_addr, extent_length, write_offset, nvf->node->serialno);
-
-	/*
 	if(MEMCPY_NON_TEMPORAL((char *)mmap_addr, buf, extent_length) == NULL) {
 		printf("%s: non-temporal memcpy failed\n", __func__);
 		fflush(NULL);
 		assert(0);
 	}
-	*/
 	//_mm_sfence();
 	//num_mfence++;
 	num_write_nontemporal++;

--- a/splitfs/fileops_nvp.c
+++ b/splitfs/fileops_nvp.c
@@ -3518,11 +3518,11 @@ RETT_PWRITE write_to_file_mmap(int file,
 	DEBUG_FILE("%s: memcpy args: buf = %p, mmap_addr = %p, length = %lu. File off = %lld. Inode = %lu\n", __func__, buf, (void *) mmap_addr, extent_length, write_offset, nvf->node->serialno);
 
 
-	int temp_fd = open("/dev/zero", O_RDONLY);
+	int temp_fd = _nvp_fileops->OPEN("/dev/zero", O_RDONLY);
 	int writeable;
 
 	if (temp_fd < 0)
-		return -1;
+		assert(0);
 
 	writeable = _nvp_fileops->READ(fd, (void *)mmap_addr, extent_length) == extent_length;
 
@@ -3535,6 +3535,9 @@ RETT_PWRITE write_to_file_mmap(int file,
 	} else {
 		assert(0);
 	}
+
+	close(temp_fd);
+	
 	//_mm_sfence();
 	//num_mfence++;
 	num_write_nontemporal++;

--- a/splitfs/fileops_nvp.c
+++ b/splitfs/fileops_nvp.c
@@ -3516,9 +3516,23 @@ RETT_PWRITE write_to_file_mmap(int file,
 #if NON_TEMPORAL_WRITES
 
 	DEBUG_FILE("%s: memcpy args: buf = %p, mmap_addr = %p, length = %lu. File off = %lld. Inode = %lu\n", __func__, buf, (void *) mmap_addr, extent_length, write_offset, nvf->node->serialno);
-	if(MEMCPY_NON_TEMPORAL((char *)mmap_addr, buf, extent_length) == NULL) {
-		printf("%s: non-temporal memcpy failed\n", __func__);
-		fflush(NULL);
+
+
+	int temp_fd = open("/dev/zero", O_RDONLY);
+	int writeable;
+
+	if (temp_fd < 0)
+		return -1;
+
+	writeable = _nvp_fileops->READ(fd, (void *)mmap_addr, extent_length) == extent_length;
+
+	if (writeable) {
+		if(MEMCPY_NON_TEMPORAL((char *)mmap_addr, buf, extent_length) == NULL) {
+			printf("%s: non-temporal memcpy failed\n", __func__);
+			fflush(NULL);
+			assert(0);
+		}
+	} else {
 		assert(0);
 	}
 	//_mm_sfence();

--- a/splitfs/fileops_nvp.c
+++ b/splitfs/fileops_nvp.c
@@ -3513,11 +3513,14 @@ RETT_PWRITE write_to_file_mmap(int file,
 #if NON_TEMPORAL_WRITES
 
 	DEBUG_FILE("%s: memcpy args: buf = %p, mmap_addr = %p, length = %lu. File off = %lld. Inode = %lu\n", __func__, buf, (void *) mmap_addr, extent_length, write_offset, nvf->node->serialno);
+
+	/*
 	if(MEMCPY_NON_TEMPORAL((char *)mmap_addr, buf, extent_length) == NULL) {
 		printf("%s: non-temporal memcpy failed\n", __func__);
 		fflush(NULL);
 		assert(0);
 	}
+	*/
 	//_mm_sfence();
 	//num_mfence++;
 	num_write_nontemporal++;

--- a/splitfs/fileops_nvp.c
+++ b/splitfs/fileops_nvp.c
@@ -3517,26 +3517,11 @@ RETT_PWRITE write_to_file_mmap(int file,
 
 	DEBUG_FILE("%s: memcpy args: buf = %p, mmap_addr = %p, length = %lu. File off = %lld. Inode = %lu\n", __func__, buf, (void *) mmap_addr, extent_length, write_offset, nvf->node->serialno);
 
-
-	int temp_fd = _nvp_fileops->OPEN("/dev/zero", O_RDONLY);
-	int writeable;
-
-	if (temp_fd < 0)
-		assert(0);
-
-	writeable = _nvp_fileops->READ(fd, (void *)mmap_addr, 1) == 1;
-
-	if (writeable) {
-		if(MEMCPY_NON_TEMPORAL((char *)mmap_addr, buf, extent_length) == NULL) {
-			printf("%s: non-temporal memcpy failed\n", __func__);
-			fflush(NULL);
-			assert(0);
-		}
-	} else {
+	if(MEMCPY_NON_TEMPORAL((void *)mmap_addr, buf, extent_length) == NULL) {
+		printf("%s: non-temporal memcpy failed\n", __func__);
+		fflush(NULL);
 		assert(0);
 	}
-
-	_nvp_fileops->CLOSE(temp_fd);
 
 	//_mm_sfence();
 	//num_mfence++;


### PR DESCRIPTION
This code fixes the assert condition that comes up during dynamic remap when there are multiple fsyncs without any appends in between 